### PR TITLE
various things

### DIFF
--- a/GTAIV/LiveSplit.GTAIV.asl
+++ b/GTAIV/LiveSplit.GTAIV.asl
@@ -13,7 +13,7 @@
 // VideoEditor (CE only): 0 in gameplay, 256 in video editor.
 // VideoEditor (pre-CE only): 0 in gameplay, 1 on save menu, 256 during vid warp freeze, 257 in menus and video editor.
 // CellphoneSubmenus (pre-CE only): Different values depending on which cellphone submenu is currently open (messages, organizer etc.) Shows 1000 if phone is not pulled out.
-// PickedUpFromGround: Starts from 0 and goes up +1 any time something is picked up from ground (money/weapons/healthpacks). Resets back to zero after vid warping or loading a save.
+// PickedUpFromGround: Starts from 0 and goes up +1 any time something is picked up from ground (money/weapons/healthpacks/armor etc.). Resets back to zero after vid warping or loading a save.
 // Xcoord, Ycoord, Zcoord are player coordinates. Zcoords are commented out as there's no use for them in autosplitting.
 // Character names are their respective mission progress percentage.
 
@@ -143,6 +143,7 @@ startup {
 		{"iStuntJumps", 0xC61464},
 		{"iMostWanted", 0xC615CC},
 		{"iRacesWon", 0xC6155C},
+		{"iHotDogs", 0xC614F8},
 	};
 
 	vars.missEnd = new Dictionary<string, int> {
@@ -397,6 +398,7 @@ startup {
 		addSetting("misc", "iMostWanted", "Most Wanted", "Split upon neutralization of any Most Wanted target", false);
 		addSetting("misc", "iRacesWon", "Races End", "Split upon winning any Brucie's race", false);
 		addSetting("misc", "iSweatshirt", "Sweatshirt", "Split upon collecting Sweatshirt on Happiness Island", false);
+		addSetting("misc", "iHotDogs", "Hotdogs", "Split upon consuming a Hotdog", false);
 
 	addSetting(null, "gameTime", "In-Game Time (Experimental)", "Game Timer shows IGT rather than Loadless time", false);
 	addSetting(null, "debug", "Debug", "Print debug messages to the Windows error console", false);
@@ -754,7 +756,7 @@ split {
 				// delay splitting for mission passed if splitOnStart is enabled
 				if (key == "iMissionsPassed" && settings["splitOnStart"]) {
 					vars.queueSplit = true;
-				} else if (settings["iPigeons"] || settings["iStuntJumps"] || settings["iMostWanted"] || settings["iRacesWon"]) {
+				} else if (settings["iPigeons"] || settings["iStuntJumps"] || settings["iMostWanted"] || settings["iRacesWon"] || settings["iHotDogs"]) {
 					return true;
 				}
 			}

--- a/GTAIV/LiveSplit.GTAIV.asl
+++ b/GTAIV/LiveSplit.GTAIV.asl
@@ -9,12 +9,12 @@
 // whiteLoadingScreen: a number that isn't 0 while white screen is showing (65536), 0 on black screen
 // LastMissionName values refer to: https://github.com/jfoster/LiveSplit.ASL/blob/stable/GTAIV/LastMissionName_details
 // isCutsceneRunning: 0 if not running, 8 if running, 10 if skipped. The cinematic mo-cap cutscenes, not scripted ones with pre-made animations.
-// ScreenFade: 0 if not fading, 15 if fading. Opening esc menu fade does _not_ fall under it.
+// MenuDelay: If new game starts from title screen, it shows 400, if from an existing game/inside game menu, it shows 0.
 // VideoEditor (CE only): 0 in gameplay, 256 in video editor.
 // VideoEditor (pre-CE only): 0 in gameplay, 1 on save menu, 256 during vid warp freeze, 257 in menus and video editor.
-// LastMenuFade (CE only): length in milliseconds of last menu screen fade that occured. In other words: in gameplay shows 800/1000 and in menus 0/1/5/400. Shows 0 from new game, until menu is opened for first time.
-// isMenuOpen (CE only): 0 in game, 1 in menus, 1 in video editor, 1 during vid warp freeze.
-// isGameplayVisible (CE only): 1 in game, 0/1 in menus, 0 in video editor, 1 during vid warp freeze.
+// CellphoneSubmenus (pre-CE only): Different values depending on which cellphone submenu is currently open (messages, organizer etc.) Shows 1000 if phone is not pulled out.
+// PickedUpFromGround: Starts from 0 and goes up +1 any time something is picked up from ground (money/weapons/healthpacks). Resets back to zero after vid warping or loading a save.
+// Xcoord, Ycoord, Zcoord are player coordinates. Zcoords are commented out as there's no use for them in autosplitting.
 // Character names are their respective mission progress percentage.
 
 // current Complete Edition
@@ -23,12 +23,14 @@ state ("GTAIV", "1.2.0.59") {
 	uint whiteLoadingScreen : 0x017B37D0;
 	int LastMissionName : 0xEB6FA8;
 	int isCutsceneRunning : 0xE9475C;
-	//int ScreenFade : 0xC39294; //unused for now
+	int MenuDelay : 0xD61520;
 	int VideoEditor : 0xD60C3C;
-	int LastMenuFade : 0xD61520;
-	int isMenuOpen : 0xD73590;
-	int isGameplayVisible : 0xC3E428;
-	
+	int PickedUpFromGround : 0x1215574;
+
+	float Xcoord : 0x124BA70;
+	float Ycoord : 0x124BA74;
+	//float Zcoord : 0x124BA78;
+
 	float Roman : 0xEB75BC;
 	float Michelle : 0xEB7640;
 	float Vlad : 0xEB75C0;
@@ -57,12 +59,14 @@ state ("GTAIV", "1.2.0.43") {
 	uint whiteLoadingScreen : 0x017B37D0;
 	int LastMissionName : 0xEB6FA8;
 	int isCutsceneRunning : 0xE9475C;
-	//int ScreenFade : 0xC39294; //unused for now
+	int MenuDelay : 0xD61520;
 	int VideoEditor : 0xD60C3C;
-	int LastMenuFade : 0xD61520;
-	int isMenuOpen : 0xD73590;
-	int isGameplayVisible : 0xC3E428;
-	
+	int PickedUpFromGround : 0x1215574;
+
+	float Xcoord : 0x124BA70;
+	float Ycoord : 0x124BA74;
+	//float Zcoord : 0x124BA78;
+
 	float Roman : 0xEB75BC;
 	float Michelle : 0xEB7640;
 	float Vlad : 0xEB75C0;
@@ -91,57 +95,148 @@ state ("GTAIV", "1.0.4.0") {
 	uint whiteLoadingScreen : 0x01223EA8;
 	int LastMissionName : 0xC60A88;
 	int isCutsceneRunning : 0xC80EBC;
-	//int ScreenFade : 0xAA9E10; //unused for now
+	int MenuDelay : 0xBC40B8;
 	int VideoEditor : 0xBCCDE0;
-	
-	float Roman : 0x00C60E7C, 0x10;
-	float Vlad : 0x00C60E80, 0x10;
-	float Jacob : 0x00C60E8C, 0x10;
-	float Faustin : 0x00C60E90, 0x10;
-	float Manny : 0x00C60E94, 0x10;
-	float Elizabeta : 0x00C60E98, 0x10;
-	float Dwayne : 0x00C60EA4, 0x10;
-	float Brucie : 0x00C60EB0, 0x10;
-	float Playboy : 0x00C60EB4, 0x10;
-	float Francis :0x00C60EB8, 0x10;
-	float ULP : 0x00C60EBC, 0x10;
-	float Packie : 0x00C60EC8, 0x10;
-	float Ray : 0x00C60ECC, 0x10;
-	float Gerry : 0x00C60ED0, 0x10;
-	float Derrick : 0x00C60ED4, 0x10;
-	float Bernie : 0x00C60ED8, 0x10;
-	float Bell : 0x00C60EDC, 0x10;
-	float Gravelli : 0x00C60EE0, 0x10;
-	float Pegorino : 0x00C60EE4, 0x10;
-	float Michelle : 0x00C60F00, 0x10;
+	int CellphoneSubmenus : 0x012257A8, 0x16C;
+	int PickedUpFromGround : 0xE02684;
+
+	float Xcoord : 0x10EE0D0;
+	float Ycoord : 0x10EE0D4;
+	//float Zcoord : 0x10EE0D8;
+
+	float Roman : 0xC60E7C, 0x10;
+	float Vlad : 0xC60E80, 0x10;
+	float Jacob : 0xC60E8C, 0x10;
+	float Faustin : 0xC60E90, 0x10;
+	float Manny : 0xC60E94, 0x10;
+	float Elizabeta : 0xC60E98, 0x10;
+	float Dwayne : 0xC60EA4, 0x10;
+	float Brucie : 0xC60EB0, 0x10;
+	float Playboy : 0xC60EB4, 0x10;
+	float Francis :0xC60EB8, 0x10;
+	float ULP : 0xC60EBC, 0x10;
+	float Packie : 0xC60EC8, 0x10;
+	float Ray : 0xC60ECC, 0x10;
+	float Gerry : 0xC60ED0, 0x10;
+	float Derrick : 0xC60ED4, 0x10;
+	float Bernie : 0xC60ED8, 0x10;
+	float Bell : 0xC60EDC, 0x10;
+	float Gravelli : 0xC60EE0, 0x10;
+	float Pegorino : 0xC60EE4, 0x10;
+	float Michelle : 0xC60F00, 0x10;
 }
 
 startup {
 	vars.offsets = new Dictionary<string, int> {
 		// newest first
-		{"1.2.0.59", -0x30CA98},
-		{"1.2.0.43", -0x30CA98},
-		{"1.2.0.32", -0x30CA28},  
-		{"1.0.8.0", -0x398940},
-		{"1.0.7.0", 0x0},
-		{"1.0.5.2", -0x1020},
-		{"1.0.6.0", -0xFE0},
-		{"1.0.0.4", -0x4B7BC8},
-		{"1.0.4.0", -0x563040},
+		{"1.2.0.59", 0x2565A8},
+		{"1.2.0.43", 0x2565A8},
+		{"1.0.4.0", 0x0},
 	};
 
 	vars.stats = new Dictionary<string, int> {
-		{"fGameTime", 0x011C3F60},
-		{"iMissionsPassed", 0x011C4460},
-		{"iMissionsFailed", 0x011C4464},
-		{"iMissionsAttempted", 0x011C4468},
-		{"iStuntJumps", 0x011C44A4},
-		{"iDrugJobs", 0x011C44DC},
-		{"iQUB3DHighScore", 0x011C45E8}, // 10,950 default hiscore
-		{"iMostWanted", 0x011C460C},
-		{"iVigilante", 0x011C4608},
-		{"iPigeons", 0x011C4610},
-		{"iRandomEncounters", 0x011C21C4},
+		{"fGameTime", 0xC60F20},
+		{"iMissionsPassed", 0xC61420},
+		{"iMissionsFailed", 0xC61424},
+		{"iMissionsAttempted", 0xC61428},
+		{"iPigeons", 0xC615D0},
+		{"iStuntJumps", 0xC61464},
+		{"iMostWanted", 0xC615CC},
+		{"iRacesWon", 0xC6155C},
+	};
+
+	vars.missEnd = new Dictionary<string, int> {
+		{"ROM1", 3235661},
+		{"ROM2", 3301197},
+		{"ROM3", 3366733},
+		{"ROM4", 3432269},
+		{"ROM5", 3497805},
+		{"ROM6", 3563341},
+		{"ROM7", 3628877},
+		{"ROM8", 842161997},
+		{"ROM9", 3759949},
+		{"ROM10", 825319245},
+		{"ROM11", 842096461},
+		{"ROM12", 858873677},
+		{"ROM13", 875650893},
+		{"FD", 909729613},
+		{"VL1", 892428109},
+		{"VL2", 909205325},
+		{"VL3", 925982541},
+		{"VL4", 942759757},
+		{"LJ1", 959536973},
+		{"LJ2", 808607565},
+		{"FA1", 858939213},
+		{"FA2", 875716429},
+		{"FA3", 892493645},
+		{"FA4", 909270861},
+		{"BK1", 942890829},
+		{"BK2", 959668045},
+		{"BK3", 808738637},
+		{"BK4", 825515853},
+		{"BK5", 842293069},
+		{"DR1", 926048077},
+		{"DR2", 942825293},
+		{"FM1", 926179149},
+		{"FM2", 942956365},
+		{"FM3", 959733581},
+		{"FM4", 808804173},
+		{"FM5", 825581389},
+		{"FM6", 842358605},
+		{"FM7", 859135821},
+		{"PM1", 943021901},
+		{"PM2", 959799117},
+		{"PM3", 808869709},
+		{"MN1", 959602509},
+		{"MN2", 808673101},
+		{"MN3", 825450317},
+		{"EL1", 842227533},
+		{"EL2", 859004749},
+		{"EL3", 875781965},
+		{"EL4", 892559181},
+		{"DM1", 859266893},
+		{"DM2", 876044109},
+		{"DM3", 892821325},
+		{"GM1", 926310221},
+		{"GM2", 943087437},
+		{"GM3", 959864653},
+		{"GM4", 808935245},
+		{"GM6", 825712461},
+		{"GM7", 842489677},
+		{"ULP1", 875913037},
+		{"ULP2", 892690253},
+		{"ULP3", 909467469},
+		{"ULP4", 926244685},
+		{"BC1", 909598541},
+		{"BC2", 926375757},
+		{"BC3", 943152973},
+		{"GG1", 943218509},
+		{"GG2", 959995725},
+		{"GG3", 809066317},
+		{"PX1", 892624717},
+		{"PX2", 875847501},
+		{"PX3", 1127231811},
+		{"PX4", 909401933},
+		{"DW1", 909336397},
+		{"DW2", 926113613},
+		{"JP1", 876109645},
+		{"JP2", 892886861},
+		{"JP3", 909664077},
+		{"JP4", 1127494211},
+		{"JP5", 926441293},
+		{"PB1", 842555213},
+		{"PB2", 959930189},
+		{"PB3", 825777997},
+		{"PB4", 859332429},
+		{"RB1", 825646925},
+		{"RB2", 842424141},
+		{"RB3", 859201357},
+		{"RB4", 875978573},
+		{"RB5", 892755789},
+		{"RB6", 909533005},
+		{"FIN1", 1229140294},
+		{"FIN4", 1179464006},
+		{"FIN6", 1128549957},
 	};
 
 	refreshRate = 60;
@@ -295,10 +390,13 @@ startup {
 			addSetting("FIN", "FIN6", "Credits", "Split after finishing credits", false);
 			
 	addSetting(null, "splitOnStart", "Split on Mission Start (Experimental)", "Delay splitting until starting any next story mission", false);
-	
-	addSetting(null, "iPigeons", "Pigeons", "Split upon extermination of any Flying Rat", false);
-	addSetting(null, "iStuntJumps", "Stunt Jumps", "Split upon completion of any Unique Stunt Jump", false);
-	addSetting(null, "iMostWanted", "Most Wanted", "Split upon neutralization of any Most Wanted target", false);
+
+	addSetting(null, "misc", "Miscellaneous", null, false);
+		addSetting("misc", "iPigeons", "Pigeons", "Split upon extermination of any Flying Rat", false);
+		addSetting("misc", "iStuntJumps", "Stunt Jumps", "Split upon completion of any Unique Stunt Jump", false);
+		addSetting("misc", "iMostWanted", "Most Wanted", "Split upon neutralization of any Most Wanted target", false);
+		addSetting("misc", "iRacesWon", "Races End", "Split upon winning any Brucie's race", false);
+		addSetting("misc", "iSweatshirt", "Sweatshirt", "Split upon collecting Sweatshirt on Happiness Island", false);
 
 	addSetting(null, "gameTime", "In-Game Time (Experimental)", "Game Timer shows IGT rather than Loadless time", false);
 	addSetting(null, "debug", "Debug", "Print debug messages to the Windows error console", false);
@@ -394,7 +492,7 @@ update {
 	if (!vars.enabled) return;
 
 	if (vars.isCE)
-	{		
+	{
 		if (vars.memoryWatchers["EpisodeID"].Current == 0) 
 		{
 			vars.correctEpisode = true;
@@ -425,8 +523,109 @@ update {
 	// check if missions attempted is set to 0.
 	bool missionCheck = vars.memoryWatchers["iMissionsAttempted"].Current == 0;
 
-	if (startCheck && timerCheck && missionCheck && vars.correctEpisode) {
+	// While loading the game from title screen
+	// allow the timer to start only upon starting new game
+	// and prevent start from firing while loading into a save.
+	// It is done by checking if user has any game saves in savefile directories.
+
+	bool noSaves = true; // by default always assume to start the timer
+	string dnn = null;
+	string stt = null;
+
+	// Scenario 1
+	// the savegames location path is dynamic - it varies between different users (different account ID) 
+	// so first check the path only up to \Profiles and then find the folder with ID and navigate to it
+	if (vars.version.ToString() == "1.2.0.59")
+	{
+		dnn = Environment.ExpandEnvironmentVariables(@"%USERPROFILE%\Documents\Rockstar Games\GTA IV\Profiles"); // after \Profiles there's a folder named after account ID
+		// check if saves directory exist
+		if (Directory.Exists(dnn))
+		{
+			string IDName = null;  // to store the name of the folder containing the account ID
+			int folderCount = 0;
+			// check the amount of folders that exist in said path
+			foreach (var dir in Directory.EnumerateDirectories(dnn))
+			{
+				folderCount++;
+
+				if (folderCount == 1)
+				{
+					// extract the folder name containing the account ID
+					IDName = Path.GetFileName(dir);
+				
+					// now that account ID is known, combine it into a full path that contains game saves
+					string fulldnn = Path.Combine(dnn, IDName);
+					//vars.debugInfo(fulldnn); // print full path
+				
+					// check if any file starting with 'SGTA4' exist inside savegames directory
+					foreach (var file in Directory.EnumerateFiles(fulldnn, "SGTA4*"))
+					{
+						// if there are no files starting with SGTA4*
+						// that means upon launching from title screen user will start the new game
+						// so the timer MUST start
+						if (file == null)
+						{
+							noSaves = true;
+						}
+						// directory isn't empty AND game isn't starting from existing savefile
+						// that means user is loading the game into a save, AND is doing it from title screen, so do NOT let the timer start
+						else if (file != null && current.MenuDelay != 0)
+						{
+							noSaves = false;
+						}
+					}
+				}
+				// directory is empty or contains more than two folders
+				// so assume default behavior and allow timer to start
+				else if (folderCount == 0 || folderCount >= 2)
+				{
+					noSaves = true;
+				}
+			}
+		}
+		// directory doesn't exist, so assume the default behavior and allow the timer to start
+		else
+		{
+			noSaves = true;
+		}
+	}
+	// Scenario 2
+	// the savegames location path is static - is always the same for any user (while using xliveless)
+	if (vars.version.ToString() == "1.0.4.0")
+	{
+		stt = Environment.ExpandEnvironmentVariables(@"%USERPROFILE%\Documents\Rockstar Games\GTA IV\savegames");
+		// check if saves directory exist
+		if (Directory.Exists(stt))
+		{
+			// check if any file starting with 'SGTA4' exist inside savegames directory
+			foreach (var file in Directory.EnumerateFiles(stt, "SGTA4*"))
+			{
+				// if there are no files starting with SGTA4*
+				// that means upon launching from title screen user will start the new game
+				// so the timer MUST start
+				if (file == null)
+				{
+					noSaves = true;
+				}
+				// directory isn't empty AND game isn't starting from existing savefile
+				// that means user is loading the game into a save, AND is doing it from title screen, so do NOT let the timer start
+				else if (file != null && current.MenuDelay != 0)
+				{
+					noSaves = false;
+				}
+			}
+		}
+		// directory doesn't exist, so assume the default behavior and allow the timer to start
+		else
+		{
+			noSaves = true;
+		}
+	}
+
+	// Timer ResetStart
+	if (startCheck && timerCheck && missionCheck && vars.correctEpisode && noSaves) {
 		vars.doResetStart = true;
+		vars.debugInfo("ResetStart");
 		vars.splits.Clear();
 	}
 
@@ -439,8 +638,6 @@ update {
 		// Stores the current phase the timer is in, so we can use the old one on the next frame.
 		vars.prevPhase = timer.CurrentPhase;
 	}
-
-
 }
 
 split {
@@ -458,158 +655,89 @@ split {
 	// =====================================================================
 	// Split on Mission End
 	// =====================================================================
-	// If setting is enabled AND specified character mission progress raises to a certain threshold AND game is not loading THEN do split.
-	// Game loading check is here to prevent splitting after doing video editor warp or loading a savegame.
-	// =====================================================================
-	
-	var mp = vars.memoryWatchers["iMissionsPassed"];
-	
-	if (settings["ROM2"] && (current.Roman > 11f && old.Roman < 8f && current.isLoading != 0)) return true;
-	if (settings["ROM3"] && (current.Roman > 18f && old.Roman < 15f && current.isLoading != 0)) return true;
-	if (settings["ROM4"] && (current.Roman > 24f && old.Roman < 22f && current.isLoading != 0)) return true;
-	if (settings["ROM5"] && (current.Roman > 31f && old.Roman < 28f && current.isLoading != 0)) return true;
-	if (settings["ROM6"] && (current.Roman > 38f && old.Roman < 35f && current.isLoading != 0)) return true;
-	if (settings["ROM7"] && (current.Roman > 44f && old.Roman < 42f && current.isLoading != 0)) return true;
-	if (settings["ROM8"] && (current.Faustin > 13f && old.Faustin < 2f && current.isLoading != 0)) return true; // Crime and Punishment
-	if (settings["ROM9"] && (current.Roman > 51f && old.Roman < 48f && current.isLoading != 0)) return true;
-	if (settings["ROM10"] && (current.Roman > 58f && old.Roman < 55f && current.isLoading != 0)) return true;
-	if (settings["ROM11"] && (current.Roman > 64f && old.Roman < 62f && current.isLoading != 0)) return true;
-	if (settings["ROM12"] && (current.Roman > 71f && old.Roman < 68f && current.isLoading != 0)) return true;
-	if (settings["ROM13"] && (current.Roman > 78f && old.Roman < 75f && current.isLoading != 0)) return true;
-		
-	if (settings["FD"] && (current.Michelle > 4f && old.Michelle < 2f && current.isLoading != 0)) return true; // 60% after First Date
-	
-	if (settings["VL1"] && (current.Vlad > 23f && old.Vlad < 2f && current.isLoading != 0)) return true;
-	if (settings["VL2"] && (current.Vlad > 48f && old.Vlad < 27f && current.isLoading != 0)) return true;
-	if (settings["VL3"] && (current.Vlad > 73f && old.Vlad < 52f && current.isLoading != 0)) return true;
-	if (settings["VL4"] && (current.Vlad > 98f && old.Vlad < 77f && current.isLoading != 0)) return true;
-	
-	if (settings["LJ1"] && (current.Jacob > 48f && old.Jacob < 2f && current.isLoading != 0)) return true;
-	if (settings["LJ2"] && (current.Jacob > 98f && old.Jacob < 77f && current.isLoading != 0)) return true;
-	
-	if (settings["FA1"] && (current.Faustin > 26f && old.Faustin < 16f && current.isLoading != 0)) return true;
-	if (settings["FA2"] && (current.Faustin > 40f && old.Faustin < 30f && current.isLoading != 0)) return true;
-	if (settings["FA3"] && (current.Faustin > 55f && old.Faustin < 44f && current.isLoading != 0)) return true;
-	if (settings["FA4"] && (current.Faustin > 69f && old.Faustin < 59f && current.isLoading != 0)) return true;
-	
-	if (settings["DR1"] && (current.Faustin > 83f && old.Faustin < 73f && current.isLoading != 0)) return true;
-	if (settings["DR2"] && (current.Faustin > 98f && old.Faustin < 87f && current.isLoading != 0)) return true;
-		
-	if (settings["BK1"] && (current.Brucie > 23f && old.Brucie < 2f && current.isLoading != 0)) return true;
-	if (settings["BK2"] && (current.Brucie > 48f && old.Brucie < 27f && current.isLoading != 0)) return true;
-	//if (settings["BK3"] //out of the closet 1
-	if (settings["BK4"] && (current.Brucie > 73f && old.Brucie < 52f && current.isLoading != 0)) return true;
-	if (settings["BK5"] && (current.Brucie > 98f && old.Brucie < 77f && current.isLoading != 0)) return true;
-	
-	if (settings["FM1"] && (current.Francis > 14f && old.Francis < 2f && current.isLoading != 0)) return true;
-	//if (settings["FM2"] //final interview 1
-	if (settings["FM3"] && (current.Francis > 31f && old.Francis < 18f && current.isLoading != 0)) return true;
-	if (settings["FM4"] && (current.Francis > 48f && old.Francis < 35f && current.isLoading != 0)) return true;
-	if (settings["FM5"] && (current.Francis > 64f  && old.Francis < 52f && current.isLoading != 0)) return true;
-	if (settings["FM6"] && (current.Francis > 81f && old.Francis < 68f && current.isLoading != 0)) return true;
-	if (settings["FM7"] && (current.Francis > 98f && old.Francis < 85f && current.isLoading != 0)) return true;
 
-	if (settings["PM1"] && (current.Packie > 31f && old.Packie < 2f && current.isLoading != 0)) return true;
-	if (settings["PM2"] && (current.Packie > 64f && old.Packie < 35f && current.isLoading != 0)) return true;
-	if (settings["PM3"] && (current.Packie > 98f && old.Packie < 68f && current.isLoading != 0)) return true;
-	
-	if (settings["MN1"] && (current.Manny > 31f && old.Manny < 2f && current.isLoading != 0)) return true;
-	if (settings["MN2"] && (current.Manny > 64f && old.Manny < 35f && current.isLoading != 0)) return true;
-	if (settings["MN3"] && (current.Manny > 98f && old.Manny < 68f && current.isLoading != 0)) return true;
-	
-	if (settings["EL1"] && (current.Elizabeta > 23f && old.Elizabeta < 2f && current.isLoading != 0)) return true;
-	if (settings["EL2"] && (current.Elizabeta > 48f && old.Elizabeta < 27f && current.isLoading != 0)) return true;
-	if (settings["EL3"] && (current.Elizabeta > 73f && old.Elizabeta < 52f && current.isLoading != 0)) return true;
-	if (settings["EL4"] && (current.Elizabeta > 98f && old.Elizabeta < 77f && current.isLoading != 0)) return true;
-	
-	if (settings["DM1"] && (current.Derrick > 31f && old.Derrick < 2f && current.isLoading != 0)) return true;
-	if (settings["DM2"] && (current.Derrick > 64f && old.Derrick < 35f && current.isLoading != 0)) return true;
-	if (settings["DM3"] && (current.Derrick > 98f && old.Derrick < 68f && current.isLoading != 0)) return true;
+	foreach (var mse in vars.missEnd) {
+		var k = mse.Key;
+		var v = mse.Value;
+		var rt = timer.CurrentTime.RealTime.GetValueOrDefault().TotalSeconds;
 
-	if (settings["GM1"] && (current.Gerry > 18f && old.Gerry < 2f && current.isLoading != 0)) return true;
-	if (settings["GM2"] && (current.Gerry > 38f && old.Gerry < 22f && current.isLoading != 0)) return true;
-	//if (settings["GM3"] // ill take her 1
-	if (settings["GM4"] && (current.Gerry > 58f && old.Gerry < 42f && current.isLoading != 0)) return true;
-	//if (settings["GM5"] // ransom, not a mission
-	if (settings["GM6"] && (current.Gerry > 78f && old.Gerry < 62f && current.isLoading != 0)) return true;
-	if (settings["GM7"] && (current.Gerry > 98f && old.Gerry < 82f && current.isLoading != 0)) return true;
-	
-	if (settings["ULP1"] && (current.ULP > 23f && old.ULP < 2f && current.isLoading != 0)) return true;
-	if (settings["ULP2"] && (current.ULP > 48f && old.ULP < 27f && current.isLoading != 0)) return true;
-	if (settings["ULP3"] && (current.ULP > 73f && old.ULP < 52f && current.isLoading != 0)) return true;
-	if (settings["ULP4"] && (current.ULP > 98f && old.ULP < 77f && current.isLoading != 0)) return true;
-	
-	if (settings["BC1"] && (current.Bernie > 31f && old.Bernie < 2f && current.isLoading != 0)) return true;
-	if (settings["BC2"] && (current.Bernie > 64f && old.Bernie < 35f && current.isLoading != 0)) return true;
-	if (settings["BC3"] && (current.Bernie > 98f && old.Bernie < 68f && current.isLoading != 0)) return true;
-	
-	if (settings["GG1"] && (current.Gravelli > 31f && old.Gravelli < 2f && current.isLoading != 0)) return true;
-	if (settings["GG2"] && (current.Gravelli > 64f && old.Gravelli < 35f && current.isLoading != 0)) return true;
-	if (settings["GG3"] && (current.Gravelli > 98f && old.Gravelli < 68f && current.isLoading != 0)) return true;
+		if (
+			// check if setting is enabled
+			settings.ContainsKey(k) && settings[k] 
+			
+			// AND hasn't been split for
+			&& !vars.splits.Contains(k)
+			
+			// AND last finished mission changes
+			&& current.LastMissionName == v && old.LastMissionName != v
+			
+			// AND timer is running for more than 1 second (to prevent split right after timer start)
+			&& rt >= 1.0
+			
+			// AND missions attempted value remains unchanged (to prevent split upon loading a savefile)
+			&& vars.memoryWatchers["iMissionsAttempted"].Current == vars.memoryWatchers["iMissionsAttempted"].Old
+			)
+		{
+			vars.splits.Add(k); // add split to hashset, as it has been split for
+			vars.debugInfo((k));
+			return true; // do split
+		}
+	}
 
-	if (settings["PX1"] && (current.Playboy > 31f && old.Playboy < 2f && current.isLoading != 0)) return true;
-	if (settings["PX2"] && (current.Playboy > 64f && old.Playboy < 35f && current.isLoading != 0)) return true;
-	//if (settings["PX3"] //holland play 1
-	if (settings["PX4"] && (current.Playboy > 98f && old.Playboy < 68f && current.isLoading != 0)) return true;
-	
-	if (settings["DW1"] && (current.Dwayne > 48f && old.Dwayne < 2f && current.isLoading != 0)) return true;
-	if (settings["DW2"] && (current.Dwayne > 98f && old.Dwayne < 52f && current.isLoading != 0)) return true;
-	
-	if (settings["JP1"] && (current.Pegorino > 23f && old.Pegorino < 2f && current.isLoading != 0)) return true;
-	if (settings["JP2"] && (current.Pegorino > 48f && old.Pegorino < 27f && current.isLoading != 0)) return true;
-	if (settings["JP3"] && (current.Pegorino > 73f && old.Pegorino < 52f && current.isLoading != 0)) return true;
-	//if (settings["JP4"] //pest control 1
-	if (settings["JP5"] && (current.Pegorino > 98f && old.Pegorino < 77f && current.isLoading != 0)) return true;
-	
-	if (settings["PB1"] && (current.Bell > 23f && old.Bell < 2f && current.isLoading != 0)) return true;
-	if (settings["PB2"] && (current.Bell > 48f && old.Bell < 27f && current.isLoading != 0)) return true;
-	if (settings["PB3"] && (current.Bell > 73f && old.Bell < 52f && current.isLoading != 0)) return true;
-	if (settings["PB4"] && (current.Bell > 98f && old.Bell < 77f && current.isLoading != 0)) return true;
-	
-	if (settings["RB1"] && (current.Ray > 14f && old.Ray < 2f && current.isLoading != 0)) return true;
-	if (settings["RB2"] && (current.Ray > 31f && old.Ray < 18f && current.isLoading != 0)) return true;
-	if (settings["RB3"] && (current.Ray > 48f && old.Ray < 35f && current.isLoading != 0)) return true;
-	if (settings["RB4"] && (current.Ray > 64f && old.Ray < 52f && current.isLoading != 0)) return true;
-	if (settings["RB5"] && (current.Ray > 81f && old.Ray < 68f && current.isLoading != 0)) return true;
-	if (settings["RB6"] && (current.Ray > 98f && old.Ray < 85f && current.isLoading != 0)) return true;
-	
-	if (settings["FIN2"] && (current.Roman > 84f && old.Roman < 82f && current.isLoading != 0)) return true; // deal || revenge
-	if (settings["FIN6"] && (current.Roman > 98f && old.Roman < 95f && current.isLoading != 0)) return true; // split after credits
-	
 	// Exceptions
 	// =====================================
 
-	// Character mission progress percentage and mission passed values are changing earlier than LastMissionName value
-	if (settings["ROM1"] && (current.LastMissionName == 3235661 && old.LastMissionName != 3235661 && current.isLoading != 0)) return true;
+	// Deal or Revenge - both missions are associated with one setting
+	if (settings["FIN2"]
+		&& !vars.splits.Contains("FIN2")
+		&& ((current.LastMissionName == 825843533 && old.LastMissionName != 825843533 && vars.memoryWatchers["iMissionsAttempted"].Current == vars.memoryWatchers["iMissionsAttempted"].Old) 
+		|| (current.LastMissionName == 842620749 && old.LastMissionName != 842620749 && vars.memoryWatchers["iMissionsAttempted"].Current == vars.memoryWatchers["iMissionsAttempted"].Old)))
+	{
+		vars.splits.Add("FIN2");
+		vars.debugInfo("FIN2");
+		return true;
+	}
 
-	// Character mission progress percentage for these missions do not increase, so LastMissionName values are used
-	if (settings["BK3"] && (current.LastMissionName == 808738637 && old.LastMissionName != 808738637 && current.isLoading != 0)) return true;
-	if (settings["FM2"] && (current.LastMissionName == 942956365 && old.LastMissionName != 942956365 && current.isLoading != 0)) return true;
-	if (settings["GM3"] && (current.LastMissionName == 959864653 && old.LastMissionName != 959864653 && current.isLoading != 0)) return true;
-	if (settings["PX3"] && (current.LastMissionName == 1127231811 && old.LastMissionName != 1127231811 && current.isLoading != 0)) return true;
-	if (settings["JP4"] && (current.LastMissionName == 1127494211 && old.LastMissionName != 1127494211 && current.isLoading != 0)) return true;
-	if (settings["FIN1"] && (current.LastMissionName == 1229140294 && old.LastMissionName != 1229140294 && current.isLoading != 0)) return true; // one last thing
-	
-	//  Mr. & Mrs. Bellic - this mission doesn't have LastMissionName value and percentage doesn't increase
+	// Mr. & Mrs. Bellic - this mission doesn't have LastMissionName value and character percentage doesn't increase
 	// so check if either of FIN2 values are unchanged, but mission passed value increases
+	var mp = vars.memoryWatchers["iMissionsPassed"];
 	if (settings["FIN3"] 
+		&& !vars.splits.Contains("FIN3")
 		&& (((current.LastMissionName == 825843533 && old.LastMissionName == 825843533) && (mp.Current == mp.Old + 1)) 
 		|| ((current.LastMissionName == 842620749 && old.LastMissionName == 842620749) && (mp.Current == mp.Old + 1))))
+	{
+		vars.splits.Add("FIN3");
+		vars.debugInfo("FIN3");
 		return true;
-		
-	if (settings["FIN4"] && (current.LastMissionName == 1179464006 && old.LastMissionName != 1179464006 && current.isLoading != 0)) return true; // in mourning
-	
+	}
+
 	// Any% / Classic Final Split - first frame of last cutscene at the end of 'A Revenger's Tragedy' or 'Out of Commission'
-	// If setting is enabled AND In Mourning is finished AND cinematic cutscene starts playing AND game is not loading at the moment:
+	// If setting is enabled AND hasn't been split for AND In Mourning is finished AND cinematic cutscene starts playing
 	// That means player completed the game a.k.a. finished any% / classic speedrun
 	// It works, because after finishing In Mourning there's no other possible cutscene to play besides the final one
-	if (settings["FIN5"] && (current.LastMissionName == 1179464006 && current.isCutsceneRunning == 8 && old.isCutsceneRunning != 8 && current.isLoading != 0)) return true;
-
+	if (settings["FIN5"] && !vars.splits.Contains("FIN5") && (current.LastMissionName == 1179464006 && current.isCutsceneRunning == 8 && old.isCutsceneRunning != 8))
+	{
+		vars.splits.Add("FIN5");
+		vars.debugInfo("FIN5 - Any% Final Split");
+		return true;
+	}
 
 
 	// =======================================================================
 	// Miscellaneous stuff to split on
 	// =======================================================================
+
+	// happiness island sweatshirt
+	// check if player has picked something up at specified location
+	if (settings["iSweatshirt"] 
+		&& !vars.splits.Contains("iSweatshirt")
+		&& ((current.PickedUpFromGround == old.PickedUpFromGround + 1) 
+		&& ((current.Xcoord > -609.34f && current.Xcoord < -606.69f) && (current.Ycoord > -769.11f && current.Ycoord < -767.08f))))
+	{
+		vars.splits.Add("iSweatshirt");
+		vars.debugInfo("iSweatshirt");
+		return true;
+	}
 
 	// loop through memory watchers and if it matches an enabled setting then check if it's increased
 	foreach (var mw in vars.memoryWatchers) {
@@ -626,7 +754,7 @@ split {
 				// delay splitting for mission passed if splitOnStart is enabled
 				if (key == "iMissionsPassed" && settings["splitOnStart"]) {
 					vars.queueSplit = true;
-				} else if (settings["iPigeons"] || settings["iStuntJumps"] || settings["iMostWanted"]) {
+				} else if (settings["iPigeons"] || settings["iStuntJumps"] || settings["iMostWanted"] || settings["iRacesWon"]) {
 					return true;
 				}
 			}
@@ -659,16 +787,18 @@ isLoading {
 	// this needs to be true to enable gameTime
 	if (settings["gameTime"]) return true;
 
-	// stop the loadless timer when the game freezes while doing video editor warp
-	if (current.VideoEditor == 256) {
-		if (vars.enabled && vars.correctEpisode) {
-			if (vars.isCE) {
-				if ((current.LastMenuFade >= 800 || current.LastMenuFade == 0) && current.isGameplayVisible == 1 && current.isMenuOpen == 1) {
-					return true;
-				}
-			} else {
-				return true;
-			}
+	// Pre-Complete Edition only: pause the loadless timer when the game freezes while doing video editor warp
+	if (vars.enabled && vars.correctEpisode && !vars.isCE && current.VideoEditor == 256) return true;
+
+	// Pre-Complete Edition only: loadless timer must continue to run during certain loading screens in multiplayer-related scenarios.
+	if (vars.enabled && vars.correctEpisode && !vars.isCE) {
+		// Opening and closing player model menu. 1047 is a value for whole multiplayer cellphone submenu.
+		if (current.CellphoneSubmenus == 1047) {
+			return false;
+		}
+		// "Disconnected from game session" screen (entering LAN lobby)
+		if ((current.Xcoord > -2001f && current.Xcoord < -1998f) && (current.Ycoord > -2001f && current.Ycoord < -1998f)) {
+			return false;
 		}
 	}
 

--- a/GTAIV/LiveSplit.GTATLAD.asl
+++ b/GTAIV/LiveSplit.GTATLAD.asl
@@ -12,12 +12,8 @@
 // isCutsceneRunning: 0 if not running, 8 if running, 10 if skipped. The cinematic mo-cap cutscenes, not scripted ones with pre-made animations.
 // MissionsAttempted: amount of attempted story missions
 // ScreenFade: 0 if not fading, 15 if fading. Opening esc menu fade does _not_ fall under it.
-// onMission: is player on a mission flag. 0 if false, 1 if true
-// VideoEditor (CE only): 0 in gameplay, 256 in video editor,
-// VideoEditor (pre-CE only): 0 in gameplay, 1 on save menu, 256 during vid warp freeze, 257 in menus and video editor,
-// LastMenuFade (CE only): length in milliseconds of last menu screen fade that occured. In other words: in gameplay shows 800/1000 and in menus 0/1/5/400. Shows 0 from new game, until menu is opened for first time.
-// isMenuOpen (CE only): 0 in game, 1 in menus, 1 in video editor, 1 during vid warp freeze.
-// isGameplayVisible (CE only): 1 in game, 0/1 in menus, 0 in video editor, 1 during vid warp freeze.
+// VideoEditor (CE only): 0 in gameplay, 256 in video editor
+// VideoEditor (pre-CE only): 0 in gameplay, 1 on save menu, 256 during vid warp freeze, 257 in menus and video editor
 // Xcoord, Ycoord, Zcoord are player coordinates. Zcoords are commented out as there's no use for them in autosplitting.
 // Characters names are their respective mission progress percentage.
 
@@ -27,14 +23,10 @@ state("GTAIV", "1.2.0.59") {
 	uint episodeID : 0xD73240;
 	uint isFirstMission : 0xD8DFD0;
 	int LastMissionName : 0xEB6FAC;
-	int isCutsceneRunning : 0xE9475C;
+	// int isCutsceneRunning : 0xE9475C;
 	int MissionsAttempted : 0xEB79D0;
 	int ScreenFade : 0xC39294;
-	int onMission : 0x1266C80;
 	int VideoEditor : 0xD60C3C;
-	int LastMenuFade : 0xD61520;
-	int isMenuOpen : 0xD73590;
-	int isGameplayVisible : 0xC3E428;
 	float Xcoord : 0x124BA70;
 	float Ycoord : 0x124BA74;
 	//float Zcoord : 0x124BA78;
@@ -49,17 +41,13 @@ state("GTAIV", "1.2.0.59") {
 // Complete Edition until 9/02/2023
 state("GTAIV", "1.2.0.43") {
 	uint isLoading : 0xD747A4;
-	uint isFirstMission : 0xD8DFD0;
 	uint episodeID : 0xD73240;
+	uint isFirstMission : 0xD8DFD0;
 	int LastMissionName : 0xEB6FAC;
-	int isCutsceneRunning : 0xE9475C;
+	// int isCutsceneRunning : 0xE9475C;
 	int MissionsAttempted : 0xEB79D0;
 	int ScreenFade : 0xC39294;
-	int onMission : 0x1266C80;
 	int VideoEditor : 0xD60C3C;
-	int LastMenuFade : 0xD61520;
-	int isMenuOpen : 0xD73590;
-	int isGameplayVisible : 0xC3E428;
 	float Xcoord : 0x124BA70;
 	float Ycoord : 0x124BA74;
 	//float Zcoord : 0x124BA78;
@@ -77,20 +65,19 @@ state("EFLC", "1.1.2.0") {
 	uint episodeID : 0xC4D7C4; // could also use 0xC619D8
 	uint isFirstMission : 0xD0D8B8;
 	int LastMissionName : 0xDA4CFC;
-	int isCutsceneRunning : 0xD073F0;
+	// int isCutsceneRunning : 0xD073F0;
 	int MissionsAttempted : 0xDA58B8;
 	int ScreenFade : 0xB17A44;
-	int onMission : 0x11E80E8;
 	int VideoEditor : 0xD6E428;
 	float Xcoord : 0x12462F0;
 	float Ycoord : 0x12462F4;
 	//float Zcoord : 0x12462F8;
-	float Billy : 0x00DA54E4, 0xC, 0x0;
-	float Jim : 0x00DA54E8, 0xC, 0x0;
-	float Stubbs : 0x00DA54F4, 0xC, 0x0;
-	float Ashley : 0x00DA54F8, 0xC, 0x0;
-	float Elizabeta : 0x00DA54FC, 0xC, 0x0;
-	float Ray : 0x00DA5500, 0xC, 0x0;
+	float Billy : 0xDA54E4, 0xC, 0x0;
+	float Jim : 0xDA54E8, 0xC, 0x0;
+	float Stubbs : 0xDA54F4, 0xC, 0x0;
+	float Ashley : 0xDA54F8, 0xC, 0x0;
+	float Elizabeta : 0xDA54FC, 0xC, 0x0;
+	float Ray : 0xDA5500, 0xC, 0x0;
 }
 
 startup {
@@ -98,8 +85,6 @@ startup {
 		// newest first
 		{"1.2.0.59", 0x1122B0},
 		{"1.2.0.43", 0x1122B0},
-		{"1.2.0.32", 0x112240},
-		{"1.1.3.0", -0xC020},
 		{"1.1.2.0", 0x0},
 	};
 
@@ -111,6 +96,30 @@ startup {
 		{"fRacesWon", 0xDA5538},
 		{"fBikesStolen", 0xDA5540},
 		{"iRandomEncounters", 0xDA5934}, 
+	};
+	
+	vars.missEnd = new Dictionary<string, List<int>> {
+		{"B3", new List<int>{50, 4456498}},
+		{"B4", new List<int>{51, 4456499}},
+		{"B5", new List<int>{52, 4456500}},
+		{"B6", new List<int>{54, 4456502}},
+		{"J1", new List<int>{55, 4456503}},
+		{"J2", new List<int>{56, 4456504}},
+		{"J3", new List<int>{12337, 1409298481}},
+		{"J4", new List<int>{12593, 1409298737}},
+		{"J5", new List<int>{12849, 1409298993}},
+		{"E1", new List<int>{53, 4456501}},
+		{"E2", new List<int>{14641, 1409300785}},
+		{"E3", new List<int>{12338, 1409298482}},
+		{"E4", new List<int>{12594, 1409298738}},
+		{"S1", new List<int>{13105, 1409299249}},
+		{"S2", new List<int>{13361, 1409299505}},
+		{"S4", new List<int>{1414087749, 1414087749}},
+		{"A1", new List<int>{14129, 1409300273}},
+		{"A2", new List<int>{14385, 1409300529}},
+		{"R1", new List<int>{12850, 1409298994}},
+		{"R2", new List<int>{13106, 1409299250}},
+		{"R3", new List<int>{13362, 1409299506}},
 	};
 
 	refreshRate = 60;
@@ -186,12 +195,12 @@ startup {
 			addSetting("S00", "S33", "Get Lost", null, false);
 			
 		addSetting("splitOnStart", "A00", "Ashley Butler", null, false);
-			addSetting("A00", "A11", "Coming Down (Experimental)", "This is a phone activated mission", false);
+			addSetting("A00", "A11", "Coming Down", null, false);
 			addSetting("A00", "A22", "Roman's Holiday", null, false);
 			
 		addSetting("splitOnStart", "R00", "Ray Boccino", null, false);
 			addSetting("R00", "R11", "Diamonds In The Rough", null, false);
-			addSetting("R00", "R22", "Collector's Item (Experimental)", "This is a phone activated mission", false);
+			addSetting("R00", "R22", "Collector's Item", null, false);
 			addSetting("R00", "R33", "Was It Worth it?", null, false);
 			
 	addSetting(null, "misc", "Miscellaneous", null, false);
@@ -304,8 +313,10 @@ update {
 	// check if missions progress with Billy is set to 0.
 	bool missionCheck = current.Billy == 0f;
 
+	// Timer ResetStart
 	if (startCheck && timerCheck && missionCheck && vars.correctEpisode) {
 		vars.doResetStart = true;
+		vars.debugInfo("ResetStart");
 		vars.splits.Clear();
 	}
 
@@ -328,264 +339,362 @@ split {
 	// =====================================================================
 	// Split on Mission End
 	// =====================================================================
-	// If setting is enabled AND specified character mission progress raises to a certain threshold AND game is not loading THEN do split.
-	// Game loading check is here to prevent splitting after doing video editor warp or loading a savegame.
-	// =====================================================================
-	
-	if (settings["B2"] && (current.Billy > 14f && old.Billy < 2f && current.isLoading != 0)) return true;
-	if (settings["B3"] && (current.Billy > 31f && old.Billy < 18f && current.isLoading != 0)) return true;
-	if (settings["B4"] && (current.Billy > 48f && old.Billy < 35f && current.isLoading != 0)) return true;
-	if (settings["B5"] && (current.Billy > 64f && old.Billy < 52f && current.isLoading != 0)) return true;
-	if (settings["B6"] && (current.Billy > 98f && old.Billy < 85f && current.isLoading != 0)) return true;
-	
-	if (settings["J1"] && (current.Jim > 18f && old.Jim < 2f && current.isLoading != 0)) return true;
-	if (settings["J2"] && (current.Jim > 38f && old.Jim < 22f && current.isLoading != 0)) return true;
-	if (settings["J3"] && (current.Jim > 58f && old.Jim < 42f && current.isLoading != 0)) return true;
-	if (settings["J4"] && (current.Jim > 78f && old.Jim < 62f && current.isLoading != 0)) return true;
-	if (settings["J5"] && (current.Jim > 98f && old.Jim < 82f && current.isLoading != 0)) return true;
-	
-	if (settings["E1"] && (current.Billy > 81f && old.Billy < 68f && current.isLoading != 0)) return true; // Buyer's Market
-	if (settings["E2"] && (current.Elizabeta > 31f && old.Elizabeta < 2f && current.isLoading != 0)) return true;
-	if (settings["E3"] && (current.Elizabeta > 64f && old.Elizabeta < 35f && current.isLoading != 0)) return true;
-	if (settings["E4"] && (current.Elizabeta > 98f && old.Elizabeta < 68f && current.isLoading != 0)) return true;
-	
-	if (settings["S1"] && (current.Stubbs > 31f && old.Stubbs < 2f && current.isLoading != 0)) return true;
-	if (settings["S2"] && (current.Stubbs > 64f && old.Stubbs < 35f && current.isLoading != 0)) return true;
-	if (settings["S4"] && (current.Stubbs > 98f && old.Stubbs < 68f && current.isLoading != 0)) return true; // split after credits
-	
-	if (settings["A1"] && (current.Ashley > 48f && old.Ashley < 2f && current.isLoading != 0)) return true;
-	if (settings["A2"] && (current.Ashley > 98f && old.Ashley < 52f && current.isLoading != 0)) return true;
-	
-	if (settings["R1"] && (current.Ray > 31f && old.Ray < 2f && current.isLoading != 0)) return true;
-	if (settings["R2"] && (current.Ray > 64f && old.Ray < 35f && current.isLoading != 0)) return true;
-	if (settings["R3"] && (current.Ray > 98f && old.Ray < 68f && current.isLoading != 0)) return true;
-		
+
+	foreach (var mse in vars.missEnd) {
+		var k = mse.Key;
+		var v = mse.Value;
+
+		if (
+			// check if setting is enabled 
+			settings.ContainsKey(k) && settings[k] 
+
+			// AND hasn't been split for
+			&& !vars.splits.Contains(k)
+
+			// AND last finished mission changes
+			&& v.Contains(current.LastMissionName) && !v.Contains(old.LastMissionName)
+
+			// AND missions attempted value remains unchanged (to prevent split upon loading a savefile)
+			&& current.MissionsAttempted == old.MissionsAttempted
+			)
+			{
+			vars.splits.Add(k); // add split to hashset, as it has been split for
+			vars.debugInfo((k));
+			return true; // do split
+		}
+	}
+
 	// Exceptions
 	// ====================================
-		
+
 	// Pretty Boy split
 	// If setting is enabled
+	//		AND hasn't been split for
 	// 		AND current mission progress with Billy is at 0% (no missions are completed - player is doing "Clean and Serene")
 	// 		AND if screen starts fading to black
 	//		AND player is in the area of "Clean and Serene" chop shop destination marker:
 	// That means the marker has been entered and split needs to happen
 	// exact marker coordinates from billy1.sco {914.23260000, 1556.08400000, 18.26000000}
 	if (settings["B1"] 
+		&& !vars.splits.Contains("B1")
 		&& (current.Billy == 0f)
 		&& (current.ScreenFade == 15 && old.ScreenFade != 15) 
 		&& ((current.Xcoord < 918.23f && current.Xcoord > 910.23f) && (current.Ycoord < 1560.08f && current.Ycoord > 1552.08f)))
+	{ 
+		vars.splits.Add("B1");
+		vars.debugInfo("B1");
 		return true;
-		
+	}
+
+	// Clean And Serene split
+	// If setting is enabled
+	//		AND the mission hasn't been split for 
+	// 		AND your progress with Billy raises from 0% (that means one mission for Billy has been finished which would be 'Clean And Serene')
+	//		AND MissionsAttempted value remains unchanged (to prevent a split while loading a savefile)
+	// That means mission has been finished and split needs to happen
+	// LastMissionName method cannot apply here, because when you start a new game from savefile
+	// the LastMissionName value carries over from savefile new game was started from.
+	// So if the new game is started from savefile that has 'Clean And Serene' finished, split fails to happen.
+	if (settings["B2"] && !vars.splits.Contains("B2") && (current.Billy > 14f && old.Billy == 0f) && (current.MissionsAttempted == old.MissionsAttempted))
+	{
+		vars.splits.Add("B2");
+		vars.debugInfo("B2");
+		return true;
+	}
+
 	// Any% / Classic Final Split - hitting last marker at the end of 'Get Lost'
 	// If setting is enabled
+	// 		AND hasn't been split for
 	//		AND 'Was It Worth it?' is last finished mission (as its the only possible story mission to complete before starting 'Get Lost')
 	//		AND player is in the area of last marker at the end of 'Get Lost' 
 	//		AND screen starts fading to black 
-	//		AND there's no cutscene running at the moment (this check is here to prevent splitting during last cutscene playing):
 	// That means marker has been entered and split needs to happen as the player completed the game a.k.a. finished any% / classic speedrun.
 	// exact marker coordinates from stubbs4.sco {-1720.96800000, 368.84040000, 24.32380000}
 	if (settings["S3"] 
+		&& !vars.splits.Contains("S3")
 		&& ((current.LastMissionName == 13362 || current.LastMissionName == 1409299506) 
 		&& ((current.Xcoord < -1716.96f && current.Xcoord > -1724.96f) && (current.Ycoord > 364.84f && current.Ycoord < 374.84f)) 
-		&& (current.ScreenFade == 15 && old.ScreenFade != 15)
-		&& (current.isCutsceneRunning == 0)))
+		&& (current.ScreenFade == 15 && old.ScreenFade != 15))) 
+	{
+		vars.splits.Add("S3");
+		vars.debugInfo("S3 - Any% Final Split");
 		return true;
-		
-	
-	
+	}
+
 	// ==================================================================
 	// Split on Mission Start
 	// ==================================================================
 	// If setting is enabled 
+	// 		AND hasn't been split for
 	//		AND specified character mission progress is at certain threshold
 	// 		AND player is in area of static mission start marker associated with this setting
-	// 		AND screen starts fading to black
-	//		AND player is not on a mission, yet (this check is here to prevent splitting when second fade-out happen, after cutscene ends):
+	// 		AND missions attempted value raises:
 	// That means mission marker has been entered, mission has been started, and split needs to happen.
-	// onMission flag changes to 1 around when screen fades fully to black.
 	// Any coordinates below are mission start markers locations taken from main.sco
 	// ===================================================================
-	
+
 	// for all Billy's missions: {-1718.45900000, 361.44560000, 24.39980000}
-	if (settings["B33"] 
+	if (settings["B33"]
+		&& !vars.splits.Contains("B33")
 		&& ((current.Billy > 14f && current.Billy < 18f)
-		&& ((current.Xcoord > -1722.45f && current.Xcoord < -1714.45f) && (current.Ycoord > 357.44f && current.Ycoord < 365.44f))
-		&& (current.ScreenFade == 15 && old.ScreenFade != 15)
-		&& (current.onMission == 0)))
+		&& ((current.Xcoord > -1728.45f && current.Xcoord < -1708.45f) && (current.Ycoord > 351.44f && current.Ycoord < 371.44f))
+		&& (current.MissionsAttempted == old.MissionsAttempted + 1))) 
+	{
+		vars.splits.Add("B33");
+		vars.debugInfo("B33");
 		return true;
+	}
 	if (settings["B44"]
+		&& !vars.splits.Contains("B44")
 		&& ((current.Billy > 31f && current.Billy < 35f)
-		&& ((current.Xcoord > -1722.45f && current.Xcoord < -1714.45f) && (current.Ycoord > 357.44f && current.Ycoord < 365.44f))
-		&& (current.ScreenFade == 15 && old.ScreenFade != 15)
-		&& (current.onMission == 0)))
+		&& ((current.Xcoord > -1728.45f && current.Xcoord < -1708.45f) && (current.Ycoord > 351.44f && current.Ycoord < 371.44f))
+		&& (current.MissionsAttempted == old.MissionsAttempted + 1))) 
+	{
+		vars.splits.Add("B44");
+		vars.debugInfo("B44");
 		return true;
+	}
 	if (settings["B55"]
+		&& !vars.splits.Contains("B55")
 		&& ((current.Billy == 50f)
-		&& ((current.Xcoord > -1722.45 && current.Xcoord < -1714.45f) && (current.Ycoord > 357.44f && current.Ycoord < 365.44f))
-		&& (current.ScreenFade == 15 && old.ScreenFade != 15)
-		&& (current.onMission == 0)))
-		return true;// Action/Reaction
+		&& ((current.Xcoord > -1728.45f && current.Xcoord < -1708.45f) && (current.Ycoord > 351.44f && current.Ycoord < 371.44f))
+		&& (current.MissionsAttempted == old.MissionsAttempted + 1)))
+	{
+		vars.splits.Add("B55");
+		vars.debugInfo("B55");
+		return true; // Action/Reaction
+	}
 	// 66.67% now Buyer's Market should've happen, but this mission is moved to Elizabeta
 	if (settings["B66"]
+		&& !vars.splits.Contains("B66")
 		&& ((current.Billy > 81f && current.Billy < 85f)
-		&& ((current.Xcoord > -1722.45f && current.Xcoord < -1714.45f) && (current.Ycoord > 357.44f && current.Ycoord < 365.44f))
-		&& (current.ScreenFade == 15 && old.ScreenFade != 15)
-		&& (current.onMission == 0)))
+		&& ((current.Xcoord > -1728.45f && current.Xcoord < -1708.45f) && (current.Ycoord > 351.44f && current.Ycoord < 371.44f))
+		&& (current.MissionsAttempted == old.MissionsAttempted + 1)))
+	{
+		vars.splits.Add("B66");
+		vars.debugInfo("B66");
 		return true; // This Shit's Cursed
-		
+	}
 	// {-1837.80200000, 281.17250000, 21.95570000}
 	if (settings["J11"]
+		&& !vars.splits.Contains("J11")
 		&& ((current.Jim == 0f)
-		&& ((current.Xcoord > -1841.8f && current.Xcoord < -1834.8f) && (current.Ycoord > 277.17f && current.Ycoord < 287.17f))
-		&& (current.ScreenFade == 15 && old.ScreenFade != 15)
-		&& (current.onMission == 0)))
+		&& ((current.Xcoord > -1847.8f && current.Xcoord < -1824.8f) && (current.Ycoord > 271.17f && current.Ycoord < 291.17f))
+		&& (current.MissionsAttempted == old.MissionsAttempted + 1)))
+	{
+		vars.splits.Add("J11");
+		vars.debugInfo("J11");
 		return true;
-		
+	}
+
 	// {-1632.97400000, 794.95300000, 28.76430000}
 	if (settings["J22"]
+		&& !vars.splits.Contains("J22")
 		&& ((current.Jim == 20f)
-		&& ((current.Xcoord > -1636.97f && current.Xcoord < -1628.97f) && (current.Ycoord > 790.95f && current.Ycoord < 798.95f))
-		&& (current.ScreenFade == 15 && old.ScreenFade != 15)
-		&& (current.onMission == 0)))
+		&& ((current.Xcoord > -1642.97f && current.Xcoord < -1622.97f) && (current.Ycoord > 784.95f && current.Ycoord < 804.95f))
+		&& (current.MissionsAttempted == old.MissionsAttempted + 1)))
+	{
+		vars.splits.Add("J22");
+		vars.debugInfo("J22");
 		return true;
-		
+	}
+
 	// {-338.90340000, 1601.72000000, 19.42150000}
 	if (settings["J33"]
+		&& !vars.splits.Contains("J33")
 		&& ((current.Jim == 40f)
-		&& ((current.Xcoord > -342.9f && current.Xcoord < -334.9f) && (current.Ycoord > 1557.72f && current.Ycoord < 1605.72f))
-		&& (current.ScreenFade == 15 && old.ScreenFade != 15)
-		&& (current.onMission == 0)))
+		&& ((current.Xcoord > -348.9f && current.Xcoord < -328.9f) && (current.Ycoord > 1591.72f && current.Ycoord < 1611.72f))
+		&& (current.MissionsAttempted == old.MissionsAttempted + 1)))
+	{
+		vars.splits.Add("J33");
+		vars.debugInfo("J33");
 		return true;
-		
+	}
+
 	// {-1460.73000000, 817.10820000, 18.56550000}
 	if (settings["J44"]
+		&& !vars.splits.Contains("J44")
 		&& ((current.Jim > 58f && current.Jim < 62f)
-		&& ((current.Xcoord > -1464.73f && current.Xcoord < -1456.73f) && (current.Ycoord > 813.1f && current.Ycoord < 821.10f))
-		&& (current.ScreenFade == 15 && old.ScreenFade != 15)
-		&& (current.onMission == 0)))
+		&& ((current.Xcoord > -1470.73f && current.Xcoord < -1450.73f) && (current.Ycoord > 807.1f && current.Ycoord < 827.10f))
+		&& (current.MissionsAttempted == old.MissionsAttempted + 1)))
+	{
+		vars.splits.Add("J44");
+		vars.debugInfo("J44");
 		return true;
-		
+	}
+
 	// {-1110.09500000, 1317.83100000, 23.43190000} 
 	if (settings["J55"]
+		&& !vars.splits.Contains("J55")
 		&& ((current.Jim == 80f)
-		&& ((current.Xcoord > -1114.09f && current.Xcoord < -1106.09f) && (current.Ycoord > 1313.83f && current.Ycoord < 1321.83f))
-		&& (current.ScreenFade == 15 && old.ScreenFade != 15)
-		&& (current.onMission == 0)))
+		&& ((current.Xcoord > -1129.09f && current.Xcoord < -1100.09f) && (current.Ycoord > 1307.83f && current.Ycoord < 13.83f))
+		&& (current.MissionsAttempted == old.MissionsAttempted + 1)))
+	{
+		vars.splits.Add("J55");
+		vars.debugInfo("J55");
 		return true;
-	
-    // for all Elizabeta's missions: {362.82160000, 1504.80200000, 15.97050000}
+	}
+
+	// for all Elizabeta's missions: {362.82160000, 1504.80200000, 15.97050000}
 	if (settings["E11"]
+		&& !vars.splits.Contains("E11")
 		&& ((current.Billy > 64f && current.Billy < 68f)
-		&& ((current.Xcoord < 366.82f && current.Xcoord > 358.82f) && (current.Ycoord < 1508.8f && current.Ycoord > 1500.8f))
-		&& (current.ScreenFade == 15 && old.ScreenFade != 15)
-		&& (current.onMission == 0)))
+		&& ((current.Xcoord < 372.82f && current.Xcoord > 352.82f) && (current.Ycoord < 1514.8f && current.Ycoord > 1496.8f))
+		&& (current.MissionsAttempted == old.MissionsAttempted + 1)))
+	{
+		vars.splits.Add("E11");
+		vars.debugInfo("E11");
 		return true; // Buyer's Market
+	}
 	if (settings["E22"]
-		&& ((current.Elizabeta == 0f)
-		&& ((current.Xcoord < 366.82f && current.Xcoord > 358.82f) && (current.Ycoord < 1508.8f && current.Ycoord > 1500.8f))
-		&& (current.ScreenFade == 15 && old.ScreenFade != 15)
-		&& (current.onMission == 0)))
+		&& !vars.splits.Contains("E22")
+		&& ((current.Elizabeta == 0f && current.Jim > 58f) // hit the pipe must be completed
+		&& ((current.Xcoord < 372.82f && current.Xcoord > 352.82f) && (current.Ycoord < 1514.8f && current.Ycoord > 1496.8f))
+		&& (current.MissionsAttempted == old.MissionsAttempted + 1)))
+	{
+		vars.splits.Add("E22");
+		vars.debugInfo("E22");
 		return true; // Heavy Toll
+	}
 	if (settings["E33"]
+		&& !vars.splits.Contains("E33")
 		&& ((current.Elizabeta > 31f && current.Elizabeta < 35f)
-		&& ((current.Xcoord < 366.82f && current.Xcoord > 358.82f) && (current.Ycoord < 1508.8f && current.Ycoord > 1500.8f))
-		&& (current.ScreenFade == 15 && old.ScreenFade != 15)
-		&& (current.onMission == 0)))
+		&& ((current.Xcoord < 372.82f && current.Xcoord > 352.82f) && (current.Ycoord < 1514.8f && current.Ycoord > 1496.8f))
+		&& (current.MissionsAttempted == old.MissionsAttempted + 1)))
+	{
+		vars.splits.Add("E33");
+		vars.debugInfo("E33");
 		return true;
+	}
 	if (settings["E44"]
+		&& !vars.splits.Contains("E44")
 		&& ((current.Elizabeta > 64f && current.Elizabeta < 68f)
-		&& ((current.Xcoord < 366.82f && current.Xcoord > 358.82f) && (current.Ycoord < 1508.8f && current.Ycoord > 1500.8f))
-		&& (current.ScreenFade == 15 && old.ScreenFade != 15)
-		&& (current.onMission == 0)))
+		&& ((current.Xcoord < 372.82f && current.Xcoord > 352.82f) && (current.Ycoord < 1514.8f && current.Ycoord > 1496.8f))
+		&& (current.MissionsAttempted == old.MissionsAttempted + 1)))
+	{
+		vars.splits.Add("E44");
+		vars.debugInfo("E44");
 		return true;
-	
+	}
+
 	// {-35.08080000, 764.47520000, 13.71320000}
 	if (settings["S11"]
-		&& ((current.Stubbs == 0f)
-		&& ((current.Xcoord > -39.08f && current.Xcoord < -31.08f) && (current.Ycoord > 760.47f && current.Ycoord < 768.47f))
-		&& (current.ScreenFade == 15 && old.ScreenFade != 15)
-		&& (current.onMission == 0)))
+		&& !vars.splits.Contains("S11")
+		&& ((current.Stubbs == 0f && current.Billy < 85f) // buyer's market must be completed
+		&& ((current.Xcoord > -45.08f && current.Xcoord < -25.08f) && (current.Ycoord > 754.47f && current.Ycoord < 774.47f))
+		&& (current.MissionsAttempted == old.MissionsAttempted + 1)))
+	{
+		vars.splits.Add("S11");
+		vars.debugInfo("S11");
 		return true;
+	}
 	// {-35.08080000, 764.47520000, 13.71320000}
 	if (settings["S22"]
+		&& !vars.splits.Contains("S22")
 		&& ((current.Stubbs > 31f && current.Stubbs < 35f)
-		&& ((current.Xcoord > -39.08f && current.Xcoord < -31.08f) && (current.Ycoord > 760.47f && current.Ycoord < 768.47f))
-		&& (current.ScreenFade == 15 && old.ScreenFade != 15)
-		&& (current.onMission == 0)))
+		&& ((current.Xcoord > -45.08f && current.Xcoord < -25.08f) && (current.Ycoord > 754.47f && current.Ycoord < 774.47f))
+		&& (current.MissionsAttempted == old.MissionsAttempted + 1)))
+	{
+		vars.splits.Add("S22");
+		vars.debugInfo("S22");
 		return true;
+	}	
+
 	// {-1718.45900000, 361.44560000, 24.39980000}
 	if (settings["S33"]
+		&& !vars.splits.Contains("S33")
 		&& ((current.Stubbs > 64f && current.Stubbs < 68f)
-		&& ((current.Xcoord > -1722.45 && current.Xcoord < -1714.45f) && (current.Ycoord > 357.44f && current.Ycoord < 365.44f))
-		&& (current.ScreenFade == 15 && old.ScreenFade != 15)
-		&& (current.onMission == 0)))
+		&& ((current.Xcoord > -1728.45f && current.Xcoord < -1708.45f) && (current.Ycoord > 351.44f && current.Ycoord < 371.44f))
+		&& (current.MissionsAttempted == old.MissionsAttempted + 1)))
+	{
+		vars.splits.Add("S33");
+		vars.debugInfo("S33");
 		return true;
-		
+	}
+	
 	// {-1469.90200000, 490.41190000, 18.56540000}
 	if (settings["A22"]
+		&& !vars.splits.Contains("A22")
 		&& ((current.Ashley == 50f)
-		&& ((current.Xcoord > -1473.9f && current.Xcoord < -1465.9f) && (current.Ycoord > 486.41f && current.Ycoord < 494.41f))
-		&& (current.ScreenFade == 15 && old.ScreenFade != 15)
-		&& (current.onMission == 0)))
+		&& ((current.Xcoord > -1479.9f && current.Xcoord < -1459.9f) && (current.Ycoord > 480.41f && current.Ycoord < 500.41f))
+		&& (current.MissionsAttempted == old.MissionsAttempted + 1)))
+	{
+		vars.splits.Add("A22");
+		vars.debugInfo("A22");
 		return true;
-		
+	}
+
 	// {-123.63790000, -256.57810000, 11.68540000}
 	if (settings["R11"]
-		&& ((current.Ray == 0f)
-		&& ((current.Xcoord > -127.63f && current.Xcoord < -119.63f) && (current.Ycoord > -260.57f && current.Ycoord < -252.57f))
-		&& (current.ScreenFade == 15 && old.ScreenFade != 15)
-		&& (current.onMission == 0)))
+		&& !vars.splits.Contains("R11")
+		&& ((current.Ray == 0f && current.Jim == 100f && current.Elizabeta == 100f) // bad standing & shifting weight must be completed
+		&& ((current.Xcoord > -133.63f && current.Xcoord < -113.63f) && (current.Ycoord > -266.57f && current.Ycoord < -246.57f))
+		&& (current.MissionsAttempted == old.MissionsAttempted + 1)))
+	{
+		vars.splits.Add("R11");
+		vars.debugInfo("R11");
 		return true;
+	}
 	// {-123.63790000, -256.57810000, 11.68540000}
 	if (settings["R33"]
+		&& !vars.splits.Contains("R33")
 		&& ((current.Ray > 64f && current.Ray < 68f)
-		&& ((current.Xcoord > -127.63f && current.Xcoord < -119.63f) && (current.Ycoord > -260.57f && current.Ycoord < -252.57f))
-		&& (current.ScreenFade == 15 && old.ScreenFade != 15)
-		&& (current.onMission == 0)))
+		&& ((current.Xcoord > -133.63f && current.Xcoord < -113.63f) && (current.Ycoord > -266.57f && current.Ycoord < -246.57f))
+		&& (current.MissionsAttempted == old.MissionsAttempted + 1)))
+	{
+		vars.splits.Add("R33");
+		vars.debugInfo("R33");
 		return true;
-	
+	}
+
 	// Exceptions
 	// ===============================
 	// These are phonecall-activated missions which do not start from static markers like others
-		
+
 	// Coming Down start split
 	// This mission is unlocked after finishing Politics
 	// If setting is enabled
+	// 		AND hasn't been split for
 	// 		AND mission progress with Ashley is at less than 49% (which is at 0%, while starting Coming Down)...
 	//		...alongside progress with Stubbs being at more than 31%... 
 	//		...which means at least one mission with him has been finished and that would be Politics (33.34% after finishing it)
-	//		AND onMission flag changes to 1 
+	//		AND game isn't loading (to assure there's no conflict between missions starting from static marker) 
 	// 		AND current missions attempted value changes (this check assures that story mission has been started, not stuff like bike thefts etc.)
-	// 		AND game is not loading (this check prevents splitting when replaying a mission after failing):
 	// That means some kind of mission has been started somewhere...
 	// ...and under such restricted circumstances only possible story mission to start would be Coming Down.
 	if (settings["A11"]
+		&& !vars.splits.Contains("A11")
 		&& ((current.Ashley < 49f && current.Stubbs > 31f)
-		&& (current.onMission == 1 && old.onMission == 0)
-		&& (current.MissionsAttempted != old.MissionsAttempted)
-		&& (current.isLoading != 0)))
+		&& (current.isLoading != 0)
+		&& (current.MissionsAttempted != old.MissionsAttempted))) 
+	{ 
+		vars.splits.Add("A11");
+		vars.debugInfo("A11");
 		return true;
-		
+	}
+
 	// Collector's Item start split
 	// This mission is unlocked after finishing Diamonds In The Rough AND Roman's Holiday
 	// If setting is enabled
 	// 		AND mission progress with Ray is at 33.34%...
 	//		...that means one mission for him has been finished and that would be Diamonds in the Rough...
 	// 		...alongside progress with Ashley being 100% (all her mission finished, which includes Roman's Holiday)
-	// 		AND onMission flag changes to 1
+	//		AND game isn't loading (to assure there's no conflict between missions starting from static marker) 
 	// 		AND current missions attempted value changes (this check assures that story mission has been started, not stuff like bike thefts etc.)
-	// 		AND game is not loading (this check prevents splitting when replaying a mission after failing):
 	// That means some kind of mission has been started somewhere...
 	// ...and under such restricted circumstances only possible story mission to start would be Collector's Item.
 	if (settings["R22"]
+		&& !vars.splits.Contains("R22")
 		&& (((current.Ray > 31f && current.Ray < 35f) && current.Ashley == 100f)
-		&& (current.onMission == 1 && old.onMission == 0)
-		&& (current.MissionsAttempted != old.MissionsAttempted)
-		&& (current.isLoading != 0)))
+		&& (current.isLoading != 0)
+		&& (current.MissionsAttempted != old.MissionsAttempted)))
+	{ 
+		vars.splits.Add("R22");
+		vars.debugInfo("R22");
 		return true;
-		
-		
-		
+	}
+
+
 	// =======================================================================
 	// Miscellaneous stuff to split on
 	// =======================================================================
@@ -623,7 +732,7 @@ start {
 
 	if (!vars.correctEpisode) return false;
 
-	return vars.doResetStart;	
+	return vars.doResetStart;
 }
 
 isLoading {
@@ -634,18 +743,8 @@ isLoading {
 	// this needs to be true to enable gameTime
 	if (settings["gameTime"]) return true;
 
-	// stop the loadless timer when the game freezes while doing video editor warp
-	if (current.VideoEditor == 256) {
-		if (vars.enabled && vars.correctEpisode) {
-			if (vars.isCE) {
-				if ((current.LastMenuFade >= 800 || current.LastMenuFade == 0) && current.isGameplayVisible == 1 && current.isMenuOpen == 1) {
-					return true;
-				}
-			} else {
-				return true;
-			}
-		}
-	}
+	// Pre-Complete Edition only: pause the loadless timer when the game freezes while doing video editor warp
+	if (vars.enabled && vars.correctEpisode && !vars.isCE && current.VideoEditor == 256) return true;
 
 	return current.isLoading == 0;
 }


### PR DESCRIPTION
IV:
fixes for loadless timer pause with some multiplayer features
3 new misc splits
1.0.4.0 stats addresses
experimental no timer start upon loading a save from title screen
IV and TLAD:
another splitting mechanism, optimalization
removed CE vid warp loadless timer exception and any addresses associated with it
improved debugger
TLAD:
split on mission start reverted how it was before - split on actual start